### PR TITLE
Add generation graph for training data and different plotting between representation and generation 

### DIFF
--- a/gqn/gqn_utils.py
+++ b/gqn/gqn_utils.py
@@ -76,9 +76,9 @@ def eta_g(canvas,
           kernel_size=PARAMS.ETA_EXTERNAL_KERNEL_SIZE,
           channels=PARAMS.IMG_CHANNELS,
           scope="eta_g"):
-  return tf.layers.conv2d(
-      canvas, filters=channels, kernel_size=kernel_size, padding='SAME',
-      name=scope)
+  with tf.variable_scope("eta_g", reuse=tf.AUTO_REUSE) as varscope:
+    return tf.layers.conv2d(
+      canvas, filters=channels, kernel_size=kernel_size, padding='SAME')
 
 
 @optional_scope

--- a/train_gqn_draw.py
+++ b/train_gqn_draw.py
@@ -156,7 +156,6 @@ def main(unparsed_argv):
         hooks=[logging_hook],
     )
 
-
 if __name__ == '__main__':
   print("Training a GQN.")
   FLAGS, UNPARSED_ARGV = ARGPARSER.parse_known_args()


### PR DESCRIPTION
1. I create generation_inference_rnn function, which is to make graph for not just inference but also generation for validating generation with not just test dataset but also training dataset without confusion. 

2. Showing representation and generation on different tensorboard image slot. Previous implementation plots generation and representation in same tensorboard imgs.
